### PR TITLE
[CI] add GitHub action to lint code

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,7 +1,6 @@
 on:
   pull_request:
-    types:
-      - opened
+    types: [opened, synchronize, reopened, ready_for_review, edited, unlocked]
     branches:
       - main
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -45,16 +45,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1
 
       - name: Install golint
         run: go get golang.org/x/lint/golint
-        working-directory: server
-
-      - name: Add golint to path
-        run: export PATH="$PATH:$(go list -f {{.Target}} golang.org/x/lint/golint)"
         working-directory: server
 
       - name: Run linter

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           node-version: 12
 
+      - name: Install Node.js dependencies
+        run: npm install
+
       - name: Run linter
         uses: wearerequired/lint-action@v1
         with:
@@ -43,6 +46,9 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1
+
+      - name: Instal golint
+        run: go get -u golang.org/x/lint/golint
 
       - name: Run linter
         uses: wearerequired/lint-action@v1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -29,6 +29,7 @@ jobs:
         uses: a-b-r-o-w-n/eslint-action@v1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          files: "./src/**/*"
           working-directory: client
 
   lint-server:
@@ -57,4 +58,4 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           golint: true
-          golint_dir: server
+          golint_dir: server/

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,55 @@
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+
+jobs:
+  lint-client:
+    defaults:
+      run:
+        working-directory: client
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Run linter
+        uses: wearerequired/lint-action@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          eslint: true
+
+
+  lint-server:
+    defaults:
+      run:
+        working-directory: server
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: setup go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1
+
+      - name: Run linter
+        uses: wearerequired/lint-action@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          golint: true
+
+  lint-markdown:
+    steps:
+      - name: Run linter
+        uses: nosborn/github-action-markdown-cli@v1.1.1
+        with:
+          files: .

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   lint-client:
+    name: Lint client code
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: client
@@ -27,6 +29,8 @@ jobs:
 
 
   lint-server:
+    name: Lint server code
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: server
@@ -47,6 +51,8 @@ jobs:
           golint: true
 
   lint-markdown:
+    name: Lint markdown files
+    runs-on: ubuntu-latest
     steps:
       - name: Run linter
         uses: nosborn/github-action-markdown-cli@v1.1.1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
+        shell: bash
         working-directory: client
 
     steps:
@@ -22,21 +23,20 @@ jobs:
           node-version: 12
 
       - name: Install Node.js dependencies
-        run: npm install
+        run: npm ci --no-audit --prefer-offline
 
       - name: Run linter
-        uses: wearerequired/lint-action@v1
+        uses: a-b-r-o-w-n/eslint-action@v1
         with:
-          github_token: ${{ secrets.github_token }}
-          eslint: true
-          eslint_dir: client
-
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          working_directory: client
 
   lint-server:
     name: Lint server code
     runs-on: ubuntu-latest
     defaults:
       run:
+        shell: bash
         working-directory: server
 
     steps:
@@ -48,8 +48,9 @@ jobs:
         with:
           go-version: 1
 
-      - name: Instal golint
+      - name: Install golint
         run: go get -u golang.org/x/lint/golint
+        working_directory: server
 
       - name: Run linter
         uses: wearerequired/lint-action@v1
@@ -57,13 +58,3 @@ jobs:
           github_token: ${{ secrets.github_token }}
           golint: true
           golint_dir: server
-
-  lint-markdown:
-    name: Lint markdown files
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Run linter
-        uses: nosborn/github-action-markdown-cli@v1.1.1
-        with:
-          files: .

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -29,7 +29,7 @@ jobs:
         uses: a-b-r-o-w-n/eslint-action@v1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          working_directory: client
+          working-directory: client
 
   lint-server:
     name: Lint server code
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install golint
         run: go get -u golang.org/x/lint/golint
-        working_directory: server
+        working-directory: server
 
       - name: Run linter
         uses: wearerequired/lint-action@v1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -50,7 +50,11 @@ jobs:
           go-version: 1
 
       - name: Install golint
-        run: go get -u golang.org/x/lint/golint
+        run: go get golang.org/x/lint/golint
+        working-directory: server
+
+      - name: Add golint to path
+        run: export PATH="$PATH:$(go list -f {{.Target}} golang.org/x/lint/golint)"
         working-directory: server
 
       - name: Run linter

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           eslint: true
+          eslint_dir: client
 
 
   lint-server:
@@ -55,10 +56,12 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           golint: true
+          golint_dir: server
 
   lint-markdown:
     name: Lint markdown files
     runs-on: ubuntu-latest
+
     steps:
       - name: Run linter
         uses: nosborn/github-action-markdown-cli@v1.1.1


### PR DESCRIPTION
This PR adds GitHubs action to lint the code using:

- `golint` for the `server` directory;
- `eslint` for the `client` directory;
- `markdownlint` for all the markdown files.